### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "GNU",
   "dependencies": {
     "cleverbot-node": "0.2.x",
-    "discord.js": "<=5.3.x",
+    "discord.js": "^6.0.0",
     "feedparser": "1.1.x",
     "google": "1.1.x",
     "google-images": "0.1.x",


### PR DESCRIPTION
We're using `discord.js 6.0.0` now. You'll need to run `npm install` again.